### PR TITLE
upgraded to be compatible with Ghost 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,14 @@
 {
   "name": "Beautiful Ghost",
-  "version": "1.0",
   "description": "Ghost porting of 'Beautiful Jekyll' theme",
-  "author": "Alberto Coletta",
-  "homepage": "https://github.com/boh717/beautiful-ghost"
+  "homepage": "https://github.com/boh717/beautiful-ghost",
+  "version": "1.1",
+  "engines": {
+    "ghost": ">=1.0.0"
+  },
+  "license": "MIT",
+  "author": {
+    "name": "Alberto Coletta",
+    "email": ""
+  }
 }

--- a/partials/head.hbs
+++ b/partials/head.hbs
@@ -23,7 +23,7 @@
 <meta property="og:title" content="{{meta_title}}" />
 <meta property="og:type" content="website" />
 <meta property="og:url" content="{{@blog.url}}{{url}}" />
-<meta property="og:image" content="{{image}}" />
+<meta property="og:image" content="{{#if feature_image}}{{image_url feature_image}}{{/if}}" />
 <meta property="og:rich_attachment" content="true" />
 
 <!-- Twitter Card tags -->
@@ -31,4 +31,4 @@
 <meta name="twitter:site" content="{{@blog.url}}{{url}}" />
 <meta name="twitter:description" content="{{meta_description}}" />
 <meta name="twitter:title" content="{{meta_title}}" />
-<meta name="twitter:image" content="{{image}}" />
+<meta name="twitter:image" content="{{#if feature_image}}{{image_url feature_image}}{{/if}}" />

--- a/partials/header_image.hbs
+++ b/partials/header_image.hbs
@@ -1,5 +1,5 @@
-<header class="header-section {{#if image}}has-img{{/if}}">
-{{#if image}}
+<header class="header-section {{#if feature_image}}has-img{{/if}}">
+{{#if feature_image}}
 <div class="big-img intro-header">
   <div class="container">
     <div class="row">


### PR DESCRIPTION
Followed [this](https://themes.ghost.org/v1.0.0/docs/migrate-to-ghost-1-0-0) guide to make the theme compatible with Ghost 1.0+