### PR TITLE
Remove redundant Card metadata

### DIFF
--- a/partials/header_blog.hbs
+++ b/partials/header_blog.hbs
@@ -14,17 +14,3 @@
 <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Lora:400,700,400italic,700italic" />
 <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,800italic,400,300,600,700,800" />
 <link rel="stylesheet" href="{{asset "css/prism.css"}}">
-
-<!-- Facebook OpenGraph tags -->
-<meta property="og:title" content="{{meta_title}}" />
-<meta property="og:type" content="website" />
-<meta property="og:url" content="{{@blog.url}}{{url}}" />
-<meta property="og:image" content="{{#if feature_image}}{{image_url feature_image}}{{/if}}" />
-<meta property="og:rich_attachment" content="true" />
-
-<!-- Twitter Card tags -->
-<meta name="twitter:card" content="summary_large_image" />
-<meta name="twitter:site" content="{{@blog.url}}{{url}}" />
-<meta name="twitter:description" content="{{meta_description}}" />
-<meta name="twitter:title" content="{{meta_title}}" />
-<meta name="twitter:image" content="{{#if feature_image}}{{image_url feature_image}}{{/if}}" />


### PR DESCRIPTION
Running this (awesome) theme on Ghost 1.16.1 and setting the Twitter Card metadata for a post results in the metadata being rendered twice in the html.

The first occurrence is rendered from the `header_blog.hbs` partial and is only partially completed - it doesn't include the description, image etc.

The second occurrence is being rendered elsewhere in Ghost (external to the template), and is complete, containing all the data entered for the post.

The impact of having the metadata appear twice is that when Twitter attempts to build the card it hits the first, incorrect, block of metadata and the resulting card is incorrect.

This PR removes the unnecessary card metadata from the template.

- You can see a blog post with the patched template here - https://johnmccabe.net/deploying-kubernetes-1-8/, note the metadata only appears once.

![screen shot 2017-11-03 at 19 55 58](https://user-images.githubusercontent.com/83862/32393365-18a1c7f8-c0d1-11e7-9b92-d9379f79c08f.png)
